### PR TITLE
Add floor toggle option

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,10 +6,22 @@
   <style>
     body { margin: 0; overflow: hidden; }
     #game { width: 100vw; height: 100vh; }
+    #options-panel {
+      position: absolute;
+      top: 10px;
+      left: 10px;
+      background: rgba(255, 255, 255, 0.8);
+      padding: 4px 8px;
+      font-family: sans-serif;
+      border-radius: 4px;
+    }
   </style>
 </head>
 <body>
   <div id="game"></div>
+  <div id="options-panel">
+    <label><input id="floorToggle" type="checkbox" checked /> Floor</label>
+  </div>
   <script type="module" src="./src/main.ts"></script>
 </body>
 </html>

--- a/src/scenes/Sandbox.ts
+++ b/src/scenes/Sandbox.ts
@@ -1,9 +1,13 @@
 import Phaser from 'phaser';
 import { Sand } from '../particles/Sand';
 import InteractionMap from '../utils/InteractionMap';
+import OptionsPanel from '../ui/OptionsPanel';
 
 export default class Sandbox extends Phaser.Scene {
+  private options!: OptionsPanel;
   create() {
+    this.options = new OptionsPanel(this);
+    this.options.init();
     // spawn sand on pointer drag
     this.input.on('pointermove', (ptr: Phaser.Input.Pointer) => {
       if (ptr.isDown) {

--- a/src/ui/OptionsPanel.ts
+++ b/src/ui/OptionsPanel.ts
@@ -1,0 +1,45 @@
+import Phaser from 'phaser';
+
+export default class OptionsPanel {
+  private floorCheckbox: HTMLInputElement | null;
+  private floorBody?: MatterJS.BodyType;
+
+  constructor(private scene: Phaser.Scene) {
+    this.floorCheckbox = document.getElementById('floorToggle') as HTMLInputElement | null;
+  }
+
+  init() {
+    if (this.floorCheckbox) {
+      this.floorCheckbox.addEventListener('change', () => this.updateFloor());
+    }
+    this.updateFloor();
+  }
+
+  private updateFloor() {
+    if (!this.floorCheckbox) return;
+    if (this.floorCheckbox.checked) {
+      if (!this.floorBody) this.createFloor();
+    } else {
+      this.removeFloor();
+    }
+  }
+
+  private createFloor() {
+    const width = Number(this.scene.game.config.width);
+    const height = Number(this.scene.game.config.height);
+    this.floorBody = this.scene.matter.add.rectangle(
+      width / 2,
+      height + 25,
+      width,
+      50,
+      { isStatic: true }
+    );
+  }
+
+  private removeFloor() {
+    if (this.floorBody) {
+      this.scene.matter.world.remove(this.floorBody);
+      this.floorBody = undefined;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add UI for toggling a floor on and off
- create OptionsPanel class to manage UI actions
- integrate OptionsPanel into the sandbox scene

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686189343e3083278ed23970c1009bb6