### PR TITLE
Add water and stone particles with selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,14 @@
   <div id="game"></div>
   <div id="options-panel">
     <label><input id="floorToggle" type="checkbox" checked /> Floor</label>
+    <div>
+      <label for="particleType">Particle:</label>
+      <select id="particleType">
+        <option value="sand">Sand</option>
+        <option value="water">Water</option>
+        <option value="stone">Stone</option>
+      </select>
+    </div>
   </div>
   <script type="module" src="./src/main.ts"></script>
 </body>

--- a/src/particles/Particle.ts
+++ b/src/particles/Particle.ts
@@ -14,7 +14,8 @@ export abstract class Particle {
   ) {
 
     this.sprite = scene.matter.add.image(x, y, texture, undefined, options);
-    this.sprite.setScale(0.5);
+    // slightly smaller visual scale for all particles
+    this.sprite.setScale(0.3);
     // Store a reference to the particle via Phaser's data manager
     this.sprite.setData('instance', this);
   }

--- a/src/particles/Stone.ts
+++ b/src/particles/Stone.ts
@@ -1,19 +1,19 @@
+import Phaser from 'phaser';
 import { Particle } from './Particle';
 import { ensureCircleTexture } from '../utils/TextureGenerator';
 
-export class Sand extends Particle {
-
+export class Stone extends Particle {
   constructor(scene: Phaser.Scene, x: number, y: number) {
-    ensureCircleTexture(scene, 'sandTexture', 0xc2b280, 3);
-    super(scene, x, y, 'sandTexture', {
+    ensureCircleTexture(scene, 'stoneTexture', 0xcccccc, 3);
+    super(scene, x, y, 'stoneTexture', {
       shape: { type: 'circle', radius: 3 },
-      density: 0.001,
+      density: 0.003,
       restitution: 0,
-      friction: 0.2
+      friction: 0.3
     });
   }
 
   update(delta: number) {
-    // custom behavior (if any) per frame
+    // custom stone behavior can be added here
   }
 }

--- a/src/particles/Water.ts
+++ b/src/particles/Water.ts
@@ -1,19 +1,19 @@
+import Phaser from 'phaser';
 import { Particle } from './Particle';
 import { ensureCircleTexture } from '../utils/TextureGenerator';
 
-export class Sand extends Particle {
-
+export class Water extends Particle {
   constructor(scene: Phaser.Scene, x: number, y: number) {
-    ensureCircleTexture(scene, 'sandTexture', 0xc2b280, 3);
-    super(scene, x, y, 'sandTexture', {
+    ensureCircleTexture(scene, 'waterTexture', 0x3399ff, 3);
+    super(scene, x, y, 'waterTexture', {
       shape: { type: 'circle', radius: 3 },
-      density: 0.001,
+      density: 0.0008,
       restitution: 0,
-      friction: 0.2
+      friction: 0.05
     });
   }
 
   update(delta: number) {
-    // custom behavior (if any) per frame
+    // custom water behavior can be added here
   }
 }

--- a/src/scenes/Sandbox.ts
+++ b/src/scenes/Sandbox.ts
@@ -1,5 +1,7 @@
 import Phaser from 'phaser';
 import { Sand } from '../particles/Sand';
+import { Water } from '../particles/Water';
+import { Stone } from '../particles/Stone';
 import InteractionMap from '../utils/InteractionMap';
 import OptionsPanel from '../ui/OptionsPanel';
 
@@ -8,10 +10,17 @@ export default class Sandbox extends Phaser.Scene {
   create() {
     this.options = new OptionsPanel(this);
     this.options.init();
-    // spawn sand on pointer drag
+    // spawn selected particle on pointer drag
     this.input.on('pointermove', (ptr: Phaser.Input.Pointer) => {
       if (ptr.isDown) {
-        new Sand(this, ptr.x, ptr.y);
+        const type = this.options.getParticleType();
+        if (type === 'water') {
+          new Water(this, ptr.x, ptr.y);
+        } else if (type === 'stone') {
+          new Stone(this, ptr.x, ptr.y);
+        } else {
+          new Sand(this, ptr.x, ptr.y);
+        }
       }
     });
 

--- a/src/ui/OptionsPanel.ts
+++ b/src/ui/OptionsPanel.ts
@@ -3,9 +3,11 @@ import Phaser from 'phaser';
 export default class OptionsPanel {
   private floorCheckbox: HTMLInputElement | null;
   private floorBody?: MatterJS.BodyType;
+  private particleSelect: HTMLSelectElement | null;
 
   constructor(private scene: Phaser.Scene) {
     this.floorCheckbox = document.getElementById('floorToggle') as HTMLInputElement | null;
+    this.particleSelect = document.getElementById('particleType') as HTMLSelectElement | null;
   }
 
   init() {
@@ -41,5 +43,9 @@ export default class OptionsPanel {
       this.scene.matter.world.remove(this.floorBody);
       this.floorBody = undefined;
     }
+  }
+
+  getParticleType(): string {
+    return this.particleSelect ? this.particleSelect.value : 'sand';
   }
 }

--- a/src/utils/TextureGenerator.ts
+++ b/src/utils/TextureGenerator.ts
@@ -1,0 +1,16 @@
+import Phaser from 'phaser';
+
+export function ensureCircleTexture(
+  scene: Phaser.Scene,
+  key: string,
+  color: number,
+  radius: number
+) {
+  if (scene.textures.exists(key)) return;
+  const size = radius * 2;
+  const graphics = scene.add.graphics({ x: 0, y: 0 });
+  graphics.fillStyle(color, 1);
+  graphics.fillCircle(radius, radius, radius);
+  graphics.generateTexture(key, size, size);
+  graphics.destroy();
+}


### PR DESCRIPTION
## Summary
- enable smaller particle scale in Particle base class
- create utility to generate colored circle textures
- implement Water and Stone particle types
- update Sand to use shared texture generator
- allow particle type selection via UI dropdown
- spawn selected particle type in Sandbox scene

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68619335e59c8327b8d0cc5314ec57cd