### PR TITLE
Add brush size slider

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,10 @@
         <option value="stone">Stone</option>
       </select>
     </div>
+    <div>
+      <label for="brushSize">Brush Size:</label>
+      <input id="brushSize" type="range" min="1" max="100" value="1" />
+    </div>
   </div>
   <script type="module" src="./src/main.ts"></script>
 </body>

--- a/src/scenes/Sandbox.ts
+++ b/src/scenes/Sandbox.ts
@@ -14,12 +14,19 @@ export default class Sandbox extends Phaser.Scene {
     this.input.on('pointermove', (ptr: Phaser.Input.Pointer) => {
       if (ptr.isDown) {
         const type = this.options.getParticleType();
-        if (type === 'water') {
-          new Water(this, ptr.x, ptr.y);
-        } else if (type === 'stone') {
-          new Stone(this, ptr.x, ptr.y);
-        } else {
-          new Sand(this, ptr.x, ptr.y);
+        const count = this.options.getBrushSize();
+        for (let i = 0; i < count; i++) {
+          const offsetX = Phaser.Math.Between(-count / 2, count / 2);
+          const offsetY = Phaser.Math.Between(-count / 2, count / 2);
+          const x = ptr.x + offsetX;
+          const y = ptr.y + offsetY;
+          if (type === 'water') {
+            new Water(this, x, y);
+          } else if (type === 'stone') {
+            new Stone(this, x, y);
+          } else {
+            new Sand(this, x, y);
+          }
         }
       }
     });

--- a/src/ui/OptionsPanel.ts
+++ b/src/ui/OptionsPanel.ts
@@ -4,10 +4,12 @@ export default class OptionsPanel {
   private floorCheckbox: HTMLInputElement | null;
   private floorBody?: MatterJS.BodyType;
   private particleSelect: HTMLSelectElement | null;
+  private brushSizeInput: HTMLInputElement | null;
 
   constructor(private scene: Phaser.Scene) {
     this.floorCheckbox = document.getElementById('floorToggle') as HTMLInputElement | null;
     this.particleSelect = document.getElementById('particleType') as HTMLSelectElement | null;
+    this.brushSizeInput = document.getElementById('brushSize') as HTMLInputElement | null;
   }
 
   init() {
@@ -47,5 +49,9 @@ export default class OptionsPanel {
 
   getParticleType(): string {
     return this.particleSelect ? this.particleSelect.value : 'sand';
+  }
+
+  getBrushSize(): number {
+    return this.brushSizeInput ? parseInt(this.brushSizeInput.value, 10) || 1 : 1;
   }
 }


### PR DESCRIPTION
## Summary
- add brush size slider UI
- store slider element in OptionsPanel and expose `getBrushSize`
- spawn multiple particles on pointer move depending on brush size

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6861954ba5e88327a4cbf6deadf8759c