### PR TITLE
Improve particle performance

### DIFF
--- a/src/particles/Particle.ts
+++ b/src/particles/Particle.ts
@@ -2,22 +2,59 @@ import Phaser from 'phaser';
 
 export abstract class Particle {
   protected sprite: Phaser.Physics.Matter.Image;
+  protected age = 0;
+  protected lifespan = 10000; // ms
+  protected scene: Phaser.Scene;
 
   constructor(
-
     scene: Phaser.Scene,
-
     x: number,
     y: number,
     texture: string,
     options: any
   ) {
-
+    this.scene = scene;
     this.sprite = scene.matter.add.image(x, y, texture, undefined, options);
     // slightly smaller visual scale for all particles
     this.sprite.setScale(0.3);
     // Store a reference to the particle via Phaser's data manager
     this.sprite.setData('instance', this);
+  }
+
+  reuse(x: number, y: number) {
+    this.scene.matter.world.add(this.sprite.body);
+    this.sprite.setPosition(x, y);
+    this.sprite.setVelocity(0, 0);
+    this.sprite.setAngularVelocity(0);
+    this.sprite.setActive(true).setVisible(true);
+    this.age = 0;
+  }
+
+  /**
+   * Called each frame by the Scene.
+   */
+  step(delta: number) {
+    this.age += delta;
+    this.update(delta);
+  }
+
+  isDead(): boolean {
+    const width = Number(this.scene.game.config.width);
+    const height = Number(this.scene.game.config.height);
+    if (this.age > this.lifespan) return true;
+    if (
+      this.sprite.x < -50 ||
+      this.sprite.x > width + 50 ||
+      this.sprite.y > height + 50
+    ) {
+      return true;
+    }
+    return false;
+  }
+
+  kill() {
+    this.scene.matter.world.remove(this.sprite.body);
+    this.sprite.setActive(false).setVisible(false);
   }
 
   abstract update(delta: number): void;

--- a/src/particles/Sand.ts
+++ b/src/particles/Sand.ts
@@ -14,6 +14,9 @@ export class Sand extends Particle {
   }
 
   update(delta: number) {
-    // custom behavior (if any) per frame
+    const height = Number(this.scene.game.config.height);
+    if (this.sprite.y > height * 0.6) {
+      this.sprite.setFixedRotation();
+    }
   }
 }

--- a/src/particles/Stone.ts
+++ b/src/particles/Stone.ts
@@ -14,6 +14,9 @@ export class Stone extends Particle {
   }
 
   update(delta: number) {
-    // custom stone behavior can be added here
+    const height = Number(this.scene.game.config.height);
+    if (this.sprite.y > height * 0.6) {
+      this.sprite.setFixedRotation();
+    }
   }
 }

--- a/src/particles/Water.ts
+++ b/src/particles/Water.ts
@@ -14,6 +14,9 @@ export class Water extends Particle {
   }
 
   update(delta: number) {
-    // custom water behavior can be added here
+    const height = Number(this.scene.game.config.height);
+    if (this.sprite.y > height * 0.6) {
+      this.sprite.setFixedRotation();
+    }
   }
 }

--- a/src/scenes/Sandbox.ts
+++ b/src/scenes/Sandbox.ts
@@ -4,12 +4,21 @@ import { Water } from '../particles/Water';
 import { Stone } from '../particles/Stone';
 import InteractionMap from '../utils/InteractionMap';
 import OptionsPanel from '../ui/OptionsPanel';
+import ParticlePool from '../utils/ParticlePool';
+import { Particle } from '../particles/Particle';
 
 export default class Sandbox extends Phaser.Scene {
   private options!: OptionsPanel;
+  private sandPool!: ParticlePool<Sand>;
+  private waterPool!: ParticlePool<Water>;
+  private stonePool!: ParticlePool<Stone>;
+  private activeParticles: Particle[] = [];
   create() {
     this.options = new OptionsPanel(this);
     this.options.init();
+    this.sandPool = new ParticlePool<Sand>((x, y) => new Sand(this, x, y));
+    this.waterPool = new ParticlePool<Water>((x, y) => new Water(this, x, y));
+    this.stonePool = new ParticlePool<Stone>((x, y) => new Stone(this, x, y));
     // spawn selected particle on pointer drag
     this.input.on('pointermove', (ptr: Phaser.Input.Pointer) => {
       if (ptr.isDown) {
@@ -20,13 +29,15 @@ export default class Sandbox extends Phaser.Scene {
           const offsetY = Phaser.Math.Between(-count / 2, count / 2);
           const x = ptr.x + offsetX;
           const y = ptr.y + offsetY;
+          let p: Particle;
           if (type === 'water') {
-            new Water(this, x, y);
+            p = this.waterPool.spawn(x, y);
           } else if (type === 'stone') {
-            new Stone(this, x, y);
+            p = this.stonePool.spawn(x, y);
           } else {
-            new Sand(this, x, y);
+            p = this.sandPool.spawn(x, y);
           }
+          this.activeParticles.push(p);
         }
       }
     });
@@ -39,5 +50,22 @@ export default class Sandbox extends Phaser.Scene {
         if (a && b) InteractionMap.handle(a, b, this.matter.world);
       }
     });
+  }
+
+  update(_time: number, delta: number) {
+    for (let i = this.activeParticles.length - 1; i >= 0; i--) {
+      const p = this.activeParticles[i];
+      p.step(delta);
+      if (p.isDead()) {
+        if (p instanceof Sand) {
+          this.sandPool.recycle(p);
+        } else if (p instanceof Water) {
+          this.waterPool.recycle(p);
+        } else if (p instanceof Stone) {
+          this.stonePool.recycle(p);
+        }
+        this.activeParticles.splice(i, 1);
+      }
+    }
   }
 }

--- a/src/utils/ParticlePool.ts
+++ b/src/utils/ParticlePool.ts
@@ -1,0 +1,20 @@
+import { Particle } from '../particles/Particle';
+
+export default class ParticlePool<T extends Particle> {
+  private pool: T[] = [];
+  constructor(private createFn: (x: number, y: number) => T) {}
+
+  spawn(x: number, y: number): T {
+    if (this.pool.length > 0) {
+      const p = this.pool.pop() as T;
+      p.reuse(x, y);
+      return p;
+    }
+    return this.createFn(x, y);
+  }
+
+  recycle(p: T) {
+    p.kill();
+    this.pool.push(p);
+  }
+}


### PR DESCRIPTION
## Summary
- add `ParticlePool` for reusing particle instances
- track particle lifetime and cull inactive ones
- update Sandbox scene to use pooling and culling
- freeze rotation for particles far from the viewport

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686196a88ae88327a67f3709ec73bbab