### PR TITLE
Add new particles and controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,11 +27,32 @@
         <option value="sand">Sand</option>
         <option value="water">Water</option>
         <option value="stone">Stone</option>
+        <option value="fire">Fire</option>
+        <option value="plant">Plant</option>
       </select>
     </div>
     <div>
       <label for="brushSize">Brush Size:</label>
       <input id="brushSize" type="range" min="1" max="100" value="1" />
+    </div>
+    <div>
+      <label for="gravityX">Gravity X:</label>
+      <input id="gravityX" type="range" min="-1" max="1" step="0.1" value="0" />
+    </div>
+    <div>
+      <label for="gravityY">Gravity Y:</label>
+      <input id="gravityY" type="range" min="-1" max="1" step="0.1" value="1" />
+    </div>
+    <div>
+      <label for="windX">Wind:</label>
+      <input id="windX" type="range" min="-0.05" max="0.05" step="0.005" value="0" />
+    </div>
+    <div>
+      <button id="saveBtn">Save</button>
+      <button id="loadBtn">Load</button>
+      <button id="resetBtn">Reset</button>
+      <button id="pauseBtn">Pause</button>
+      <button id="stepBtn">Step</button>
     </div>
   </div>
   <script type="module" src="./src/main.ts"></script>

--- a/src/particles/Fire.ts
+++ b/src/particles/Fire.ts
@@ -1,0 +1,21 @@
+import { Particle } from './Particle';
+import { ensureCircleTexture } from '../utils/TextureGenerator';
+import Phaser from 'phaser';
+
+export class Fire extends Particle {
+  constructor(scene: Phaser.Scene, x: number, y: number) {
+    ensureCircleTexture(scene, 'fireTexture', 0xff6600, 3);
+    super(scene, x, y, 'fireTexture', {
+      shape: { type: 'circle', radius: 3 },
+      density: 0.0005,
+      restitution: 0,
+      friction: 0
+    });
+    this.lifespan = 5000;
+  }
+
+  update(_delta: number) {
+    // Fire slowly rises a bit
+    this.sprite.applyForce({ x: 0, y: -0.00001 });
+  }
+}

--- a/src/particles/Particle.ts
+++ b/src/particles/Particle.ts
@@ -57,5 +57,25 @@ export abstract class Particle {
     this.sprite.setActive(false).setVisible(false);
   }
 
+  applyForce(x: number, y: number) {
+    this.sprite.applyForce({ x, y });
+  }
+
+  getPosition() {
+    return { x: this.sprite.x, y: this.sprite.y };
+  }
+
+  getVelocity() {
+    return {
+      x: (this.sprite.body as MatterJS.BodyType).velocity.x,
+      y: (this.sprite.body as MatterJS.BodyType).velocity.y
+    };
+  }
+
+  setState(x: number, y: number, vx: number, vy: number) {
+    this.sprite.setPosition(x, y);
+    this.sprite.setVelocity(vx, vy);
+  }
+
   abstract update(delta: number): void;
 }

--- a/src/particles/Plant.ts
+++ b/src/particles/Plant.ts
@@ -1,0 +1,19 @@
+import { Particle } from './Particle';
+import { ensureCircleTexture } from '../utils/TextureGenerator';
+import Phaser from 'phaser';
+
+export class Plant extends Particle {
+  constructor(scene: Phaser.Scene, x: number, y: number) {
+    ensureCircleTexture(scene, 'plantTexture', 0x33cc33, 3);
+    super(scene, x, y, 'plantTexture', {
+      shape: { type: 'circle', radius: 3 },
+      density: 0.001,
+      restitution: 0,
+      friction: 0.2
+    });
+  }
+
+  update(_delta: number) {
+    // Plant does nothing special for now
+  }
+}

--- a/src/scenes/Sandbox.ts
+++ b/src/scenes/Sandbox.ts
@@ -2,6 +2,8 @@ import Phaser from 'phaser';
 import { Sand } from '../particles/Sand';
 import { Water } from '../particles/Water';
 import { Stone } from '../particles/Stone';
+import { Fire } from '../particles/Fire';
+import { Plant } from '../particles/Plant';
 import InteractionMap from '../utils/InteractionMap';
 import OptionsPanel from '../ui/OptionsPanel';
 import ParticlePool from '../utils/ParticlePool';
@@ -12,13 +14,25 @@ export default class Sandbox extends Phaser.Scene {
   private sandPool!: ParticlePool<Sand>;
   private waterPool!: ParticlePool<Water>;
   private stonePool!: ParticlePool<Stone>;
+  private firePool!: ParticlePool<Fire>;
+  private plantPool!: ParticlePool<Plant>;
   private activeParticles: Particle[] = [];
+  private paused = false;
+  private stepOnce = false;
   create() {
     this.options = new OptionsPanel(this);
     this.options.init();
     this.sandPool = new ParticlePool<Sand>((x, y) => new Sand(this, x, y));
     this.waterPool = new ParticlePool<Water>((x, y) => new Water(this, x, y));
     this.stonePool = new ParticlePool<Stone>((x, y) => new Stone(this, x, y));
+    this.firePool = new ParticlePool<Fire>((x, y) => new Fire(this, x, y));
+    this.plantPool = new ParticlePool<Plant>((x, y) => new Plant(this, x, y));
+
+    this.events.on('save', this.saveState, this);
+    this.events.on('load', this.loadState, this);
+    this.events.on('reset', this.resetWorld, this);
+    this.events.on('pause', () => (this.paused = !this.paused));
+    this.events.on('step', () => (this.stepOnce = true));
     // spawn selected particle on pointer drag
     this.input.on('pointermove', (ptr: Phaser.Input.Pointer) => {
       if (ptr.isDown) {
@@ -34,6 +48,10 @@ export default class Sandbox extends Phaser.Scene {
             p = this.waterPool.spawn(x, y);
           } else if (type === 'stone') {
             p = this.stonePool.spawn(x, y);
+          } else if (type === 'fire') {
+            p = this.firePool.spawn(x, y);
+          } else if (type === 'plant') {
+            p = this.plantPool.spawn(x, y);
           } else {
             p = this.sandPool.spawn(x, y);
           }
@@ -53,8 +71,13 @@ export default class Sandbox extends Phaser.Scene {
   }
 
   update(_time: number, delta: number) {
+    if (this.paused && !this.stepOnce) {
+      return;
+    }
+    const wind = this.options.getWindX();
     for (let i = this.activeParticles.length - 1; i >= 0; i--) {
       const p = this.activeParticles[i];
+      p.applyForce(wind, 0);
       p.step(delta);
       if (p.isDead()) {
         if (p instanceof Sand) {
@@ -63,9 +86,57 @@ export default class Sandbox extends Phaser.Scene {
           this.waterPool.recycle(p);
         } else if (p instanceof Stone) {
           this.stonePool.recycle(p);
+        } else if (p instanceof Fire) {
+          this.firePool.recycle(p);
+        } else if (p instanceof Plant) {
+          this.plantPool.recycle(p);
         }
         this.activeParticles.splice(i, 1);
       }
+    }
+    this.stepOnce = false;
+  }
+
+  private resetWorld() {
+    for (const p of this.activeParticles) {
+      if (p instanceof Sand) this.sandPool.recycle(p);
+      else if (p instanceof Water) this.waterPool.recycle(p);
+      else if (p instanceof Stone) this.stonePool.recycle(p);
+      else if (p instanceof Fire) this.firePool.recycle(p);
+      else if (p instanceof Plant) this.plantPool.recycle(p);
+    }
+    this.activeParticles = [];
+  }
+
+  private saveState() {
+    const data = this.activeParticles.map(p => {
+      const pos = p.getPosition();
+      const vel = p.getVelocity();
+      let type = 'sand';
+      if (p instanceof Water) type = 'water';
+      else if (p instanceof Stone) type = 'stone';
+      else if (p instanceof Fire) type = 'fire';
+      else if (p instanceof Plant) type = 'plant';
+      return { type, x: pos.x, y: pos.y, vx: vel.x, vy: vel.y };
+    });
+    localStorage.setItem('sandboxSave', JSON.stringify(data));
+  }
+
+  private loadState() {
+    const raw = localStorage.getItem('sandboxSave');
+    if (!raw) return;
+    this.resetWorld();
+    const arr = JSON.parse(raw) as any[];
+    for (const obj of arr) {
+      let p: Particle;
+      const { type, x, y, vx, vy } = obj;
+      if (type === 'water') p = this.waterPool.spawn(x, y);
+      else if (type === 'stone') p = this.stonePool.spawn(x, y);
+      else if (type === 'fire') p = this.firePool.spawn(x, y);
+      else if (type === 'plant') p = this.plantPool.spawn(x, y);
+      else p = this.sandPool.spawn(x, y);
+      p.setState(x, y, vx, vy);
+      this.activeParticles.push(p);
     }
   }
 }

--- a/src/ui/OptionsPanel.ts
+++ b/src/ui/OptionsPanel.ts
@@ -5,17 +5,44 @@ export default class OptionsPanel {
   private floorBody?: MatterJS.BodyType;
   private particleSelect: HTMLSelectElement | null;
   private brushSizeInput: HTMLInputElement | null;
+  private gravityXInput: HTMLInputElement | null;
+  private gravityYInput: HTMLInputElement | null;
+  private windXInput: HTMLInputElement | null;
+  private saveBtn: HTMLButtonElement | null;
+  private loadBtn: HTMLButtonElement | null;
+  private resetBtn: HTMLButtonElement | null;
+  private pauseBtn: HTMLButtonElement | null;
+  private stepBtn: HTMLButtonElement | null;
 
   constructor(private scene: Phaser.Scene) {
     this.floorCheckbox = document.getElementById('floorToggle') as HTMLInputElement | null;
     this.particleSelect = document.getElementById('particleType') as HTMLSelectElement | null;
     this.brushSizeInput = document.getElementById('brushSize') as HTMLInputElement | null;
+    this.gravityXInput = document.getElementById('gravityX') as HTMLInputElement | null;
+    this.gravityYInput = document.getElementById('gravityY') as HTMLInputElement | null;
+    this.windXInput = document.getElementById('windX') as HTMLInputElement | null;
+    this.saveBtn = document.getElementById('saveBtn') as HTMLButtonElement | null;
+    this.loadBtn = document.getElementById('loadBtn') as HTMLButtonElement | null;
+    this.resetBtn = document.getElementById('resetBtn') as HTMLButtonElement | null;
+    this.pauseBtn = document.getElementById('pauseBtn') as HTMLButtonElement | null;
+    this.stepBtn = document.getElementById('stepBtn') as HTMLButtonElement | null;
   }
 
   init() {
     if (this.floorCheckbox) {
       this.floorCheckbox.addEventListener('change', () => this.updateFloor());
     }
+    if (this.gravityXInput || this.gravityYInput) {
+      const update = () => this.updateGravity();
+      this.gravityXInput?.addEventListener('input', update);
+      this.gravityYInput?.addEventListener('input', update);
+      this.updateGravity();
+    }
+    this.saveBtn?.addEventListener('click', () => this.scene.events.emit('save'));
+    this.loadBtn?.addEventListener('click', () => this.scene.events.emit('load'));
+    this.resetBtn?.addEventListener('click', () => this.scene.events.emit('reset'));
+    this.pauseBtn?.addEventListener('click', () => this.scene.events.emit('pause'));
+    this.stepBtn?.addEventListener('click', () => this.scene.events.emit('step'));
     this.updateFloor();
   }
 
@@ -25,6 +52,15 @@ export default class OptionsPanel {
       if (!this.floorBody) this.createFloor();
     } else {
       this.removeFloor();
+    }
+  }
+
+  private updateGravity() {
+    if (this.gravityXInput && this.gravityYInput) {
+      const gx = parseFloat(this.gravityXInput.value);
+      const gy = parseFloat(this.gravityYInput.value);
+      this.scene.matter.world.gravity.x = gx;
+      this.scene.matter.world.gravity.y = gy;
     }
   }
 
@@ -53,5 +89,9 @@ export default class OptionsPanel {
 
   getBrushSize(): number {
     return this.brushSizeInput ? parseInt(this.brushSizeInput.value, 10) || 1 : 1;
+  }
+
+  getWindX(): number {
+    return this.windXInput ? parseFloat(this.windXInput.value) || 0 : 0;
   }
 }

--- a/src/utils/InteractionMap.ts
+++ b/src/utils/InteractionMap.ts
@@ -1,6 +1,9 @@
 import Phaser from 'phaser';
 import { Particle } from '../particles/Particle';
 import { Sand } from '../particles/Sand';
+import { Fire } from '../particles/Fire';
+import { Water } from '../particles/Water';
+import { Plant } from '../particles/Plant';
 
 type ParticleInstance = Particle;
 
@@ -14,8 +17,22 @@ export default {
     const b = bGO.getData('instance') as ParticleInstance | undefined;
     if (!a || !b) return;
 
-    // Example rule: sand colliding with sand currently has no effect.
+    // sand with sand -> no effect
     if (a instanceof Sand && b instanceof Sand) {
+      return;
+    }
+
+    // fire burns plant
+    if ((a instanceof Fire && b instanceof Plant) || (a instanceof Plant && b instanceof Fire)) {
+      if (a instanceof Plant) a.kill();
+      if (b instanceof Plant) b.kill();
+      return;
+    }
+
+    // water extinguishes fire
+    if ((a instanceof Fire && b instanceof Water) || (a instanceof Water && b instanceof Fire)) {
+      if (a instanceof Fire) a.kill();
+      if (b instanceof Fire) b.kill();
       return;
     }
 


### PR DESCRIPTION
## Summary
- create Fire and Plant particles
- expand options UI with gravity, wind and control buttons
- extend options panel logic for new controls and events
- add wind, pause, save/load and reset handling in Sandbox scene
- implement fire-plant and water-fire interactions

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68644674acb4832798ef3eceeae45767