### PR TITLE
Fix click particle spawn coordinates

### DIFF
--- a/src/scenes/Sandbox.ts
+++ b/src/scenes/Sandbox.ts
@@ -39,8 +39,8 @@ export default class Sandbox extends Phaser.Scene {
       for (let i = 0; i < count; i++) {
         const offsetX = Phaser.Math.Between(-count / 2, count / 2);
         const offsetY = Phaser.Math.Between(-count / 2, count / 2);
-        const x = ptr.x + offsetX;
-        const y = ptr.y + offsetY;
+        const x = ptr.worldX + offsetX;
+        const y = ptr.worldY + offsetY;
         let p: Particle;
         if (type === 'water') {
           p = this.waterPool.spawn(x, y);


### PR DESCRIPTION
## Summary
- spawn particles using pointer world coordinates to ensure correct click placement

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686485cecd2c8327b8d2191b5a0c798d