### PR TITLE
Fix particle spawn world coords

### DIFF
--- a/src/scenes/Sandbox.ts
+++ b/src/scenes/Sandbox.ts
@@ -39,8 +39,9 @@ export default class Sandbox extends Phaser.Scene {
       for (let i = 0; i < count; i++) {
         const offsetX = Phaser.Math.Between(-count / 2, count / 2);
         const offsetY = Phaser.Math.Between(-count / 2, count / 2);
-        const x = ptr.worldX + offsetX;
-        const y = ptr.worldY + offsetY;
+        const worldPoint = ptr.positionToCamera(this.cameras.main);
+        const x = worldPoint.x + offsetX;
+        const y = worldPoint.y + offsetY;
         let p: Particle;
         if (type === 'water') {
           p = this.waterPool.spawn(x, y);


### PR DESCRIPTION
## Summary
- use camera world coordinates when spawning particles

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686488dfcee48327bc4484d4acd777c8